### PR TITLE
Remove Python 2 support

### DIFF
--- a/cpuset.spec
+++ b/cpuset.spec
@@ -36,7 +36,6 @@ Group:          System/Management
 URL:            https://github.com/lpechacek/cpuset
 Source:         https://github.com/lpechacek/cpuset/archive/v%{version}.tar.gz
 BuildRequires:  %{pyver}-setuptools
-Requires:       %{pyver}-future
 
 %description
 Cpuset is a Python application for using the cpuset facilities in

--- a/cpuset/commands/common.py
+++ b/cpuset/commands/common.py
@@ -1,7 +1,6 @@
 """Common functions and variables for all commands
 """
 
-from __future__ import unicode_literals
 __copyright__ = """
 Copyright (C) 2007-2010 Novell Inc.
 Copyright (C) 2013-2018 SUSE

--- a/cpuset/commands/mem.py
+++ b/cpuset/commands/mem.py
@@ -1,7 +1,6 @@
 """Memory node manipulation command
 """
 
-from __future__ import unicode_literals
 __copyright__ = """
 Copyright (C) 2007-2010 Novell Inc.
 Copyright (C) 2013-2018 SUSE

--- a/cpuset/commands/proc.py
+++ b/cpuset/commands/proc.py
@@ -1,9 +1,6 @@
 """Process manipulation command
 """
 
-from __future__ import unicode_literals
-from builtins import str
-from future.utils import lrange
 __copyright__ = """
 Copyright (C) 2007-2010 Novell Inc.
 Copyright (C) 2013-2018 SUSE
@@ -624,7 +621,7 @@ def pidspec_to_list(pidspec, fset=None, threads=False):
                 log.debug(' added single pid: %s', items[0])
         elif len(items) == 2:
             # a range of pids, only include those that exist
-            rng = [str(x) for x in lrange(int(items[0]), int(items[1])+1)
+            rng = [str(x) for x in range(int(items[0]), int(items[1])+1)
                            if os.access('/proc/'+str(x), os.F_OK)]
             if fset:
                 for tsk in rng:

--- a/cpuset/commands/set.py
+++ b/cpuset/commands/set.py
@@ -1,8 +1,6 @@
 """Cpuset manipulation command
 """
 
-from __future__ import unicode_literals
-from builtins import str
 __copyright__ = """
 Copyright (C) 2007-2010 Novell Inc.
 Copyright (C) 2013-2018 SUSE

--- a/cpuset/commands/shield.py
+++ b/cpuset/commands/shield.py
@@ -1,8 +1,6 @@
 """Shield supercommand
 """
 
-from __future__ import unicode_literals
-from builtins import str
 __copyright__ = """
 Copyright (C) 2007-2010 Novell Inc.
 Copyright (C) 2013-2018 SUSE

--- a/cpuset/config.py
+++ b/cpuset/config.py
@@ -7,11 +7,7 @@ if desired.  The class variables are given default values in the module source.
 Anything found in the configuration files in the list of paths will override
 these defaults.
 """
-from __future__ import unicode_literals
-from __future__ import print_function
 
-from future import standard_library
-standard_library.install_aliases()
 __copyright__ = """
 Copyright (C) 2009-2010 Novell Inc.
 Copyright (C) 2013-2018 SUSE

--- a/cpuset/cset.py
+++ b/cpuset/cset.py
@@ -1,12 +1,8 @@
 """Cpuset class and cpuset graph, importing module will create model
 """
-from __future__ import unicode_literals
-from __future__ import print_function
-from future.utils import lrange
 
 import io
-from builtins import str
-from builtins import object
+
 __copyright__ = """
 Copyright (C) 2007-2010 Novell Inc.
 Copyright (C) 2013-2017 SUSE
@@ -384,8 +380,8 @@ def cpuspec_to_hex(cpuspec):
             number |= 1 << int(items[0])
         elif len(items) == 2: 
             il = [int(ii) for ii in items]
-            if il[1] >= il[0]: rng = lrange(il[0], il[1]+1)
-            else: rng = lrange(il[1], il[0]+1)
+            if il[1] >= il[0]: rng = list(range(il[0], il[1]+1))
+            else: rng = list(range(il[1], il[0]+1))
             log.debug(' group=%s has cpu range of %s', sub, rng)
             for num in rng: number |= 1 << num
         else:
@@ -407,7 +403,7 @@ def memspec_check(memspec):
 
 def cpuspec_inverse(cpuspec):
     """calculate inverse of cpu specification"""
-    cpus = [0 for x in lrange(maxcpu+1)]
+    cpus = [0 for x in range(maxcpu+1)]
     groups = cpuspec.split(',')
     log.debug("cpuspec_inverse(%s) maxcpu=%d groups=%d", 
               cpuspec, maxcpu, len(groups))
@@ -420,19 +416,19 @@ def cpuspec_inverse(cpuspec):
                 continue
             cpus[int(items[0])] = 1
         elif len(items) == 2:
-            for x in lrange(int(items[0]), int(items[1])+1):
+            for x in range(int(items[0]), int(items[1])+1):
                 cpus[x] = 1
         else:
             raise CpusetException("cpuspec(%s) has bad group %s" % (cpuspec, set))
     log.debug("cpuspec array: %s", cpus)
     # calculate inverse of array
-    for x in lrange(0, len(cpus)):
+    for x in range(0, len(cpus)):
         cpus[x] = int(cpus[x] == 0)
     log.debug("      inverse: %s", cpus)
     # build cpuspec expression
     nspec = ""
     ingrp = False
-    for x in lrange(0, len(cpus)):
+    for x in range(0, len(cpus)):
         if cpus[x] == 0 and ingrp:
             nspec += str(begin)
             if x > begin+1: 

--- a/cpuset/main.py
+++ b/cpuset/main.py
@@ -1,12 +1,6 @@
 """Front end command line tool for Linux cpusets
 """
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import absolute_import
 
-from future import standard_library
-standard_library.install_aliases()
-from builtins import str
 __copyright__ = """
 Copyright (C) 2007-2010 Novell Inc.
 Copyright (C) 2013-2018 SUSE

--- a/cpuset/util.py
+++ b/cpuset/util.py
@@ -1,11 +1,6 @@
 """Utility functions
 """
-from __future__ import unicode_literals
-from __future__ import print_function
-from future.utils import lrange
 
-from builtins import chr
-from builtins import object
 __copyright__ = """
 Copyright (C) 2007-2010 Novell Inc.
 Copyright (C) 2013-2018 SUSE
@@ -67,9 +62,9 @@ class ProgressBar(object):
         self.f=sys.stdout
         if not self.finalcount: return
         self.f.write('[')
-        for i in lrange(50): self.f.write(' ')
+        for i in range(50): self.f.write(' ')
         self.f.write(']%')
-        for i in lrange(52): self.f.write('\b')
+        for i in range(52): self.f.write('\b')
 
     def __call__(self, count):
         self.progress(count)
@@ -91,7 +86,7 @@ class ProgressBar(object):
         blockcount=percentcomplete//2
         if not config.mread:
             if blockcount > self.blockcount:
-                for i in lrange(self.blockcount,blockcount):
+                for i in range(self.blockcount,blockcount):
                     self.f.write(self.block)
                     self.f.flush()
 

--- a/cpuset/version.py
+++ b/cpuset/version.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 __copyright__ = """
 Copyright (C) 2007-2010 Novell Inc.
 Copyright (C) 2013-2018 SUSE

--- a/t/test_cset.py
+++ b/t/test_cset.py
@@ -4,8 +4,6 @@
 #
 # Feel free to improve the unit test.
 
-from __future__ import unicode_literals
-from __future__ import print_function
 from cpuset import cset
 from cpuset.util import CpusetException
 import unittest

--- a/t/test_util.py
+++ b/t/test_util.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from cpuset import util,config
 import time
 


### PR DESCRIPTION
Python 2 support is not declared in setup.py, but since Python 2 has been end of life since the beginning of 2020, remove the use of the future module, and other __future__ imports.